### PR TITLE
namespace aware proxier and lb

### DIFF
--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/proxy/config/config.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/proxy/config/config.go
@@ -127,19 +127,19 @@ func (s *endpointsStore) Merge(source string, change interface{}) error {
 	case ADD:
 		glog.V(4).Infof("Adding new endpoint from source %s : %+v", source, update.Endpoints)
 		for _, value := range update.Endpoints {
-			endpoints[value.Name] = value
+			endpoints[value.Namespace + ":" + value.Name] = value
 		}
 	case REMOVE:
 		glog.V(4).Infof("Removing an endpoint %+v", update)
 		for _, value := range update.Endpoints {
-			delete(endpoints, value.Name)
+			delete(endpoints, value.Namespace + ":" + value.Name)
 		}
 	case SET:
 		glog.V(4).Infof("Setting endpoints %+v", update)
 		// Clear the old map entries by just creating a new map
 		endpoints = make(map[string]api.Endpoints)
 		for _, value := range update.Endpoints {
-			endpoints[value.Name] = value
+			endpoints[value.Namespace + ":" +value.Name] = value
 		}
 	default:
 		glog.V(4).Infof("Received invalid update type: %v", update)
@@ -222,19 +222,19 @@ func (s *serviceStore) Merge(source string, change interface{}) error {
 	case ADD:
 		glog.V(4).Infof("Adding new service from source %s : %+v", source, update.Services)
 		for _, value := range update.Services {
-			services[value.Name] = value
+			services[value.Namespace + ":" +value.Name] = value
 		}
 	case REMOVE:
 		glog.V(4).Infof("Removing a service %+v", update)
 		for _, value := range update.Services {
-			delete(services, value.Name)
+			delete(services, value.Namespace + ":" +value.Name)
 		}
 	case SET:
 		glog.V(4).Infof("Setting services %+v", update)
 		// Clear the old map entries by just creating a new map
 		services = make(map[string]api.Service)
 		for _, value := range update.Services {
-			services[value.Name] = value
+			services[value.Namespace + ":" +value.Name] = value
 		}
 	default:
 		glog.V(4).Infof("Received invalid update type: %v", update)

--- a/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/proxy/proxier.go
+++ b/Godeps/_workspace/src/github.com/GoogleCloudPlatform/kubernetes/pkg/proxy/proxier.go
@@ -463,28 +463,29 @@ func (proxier *Proxier) OnUpdate(services []api.Service) {
 	glog.V(4).Infof("Received update notice: %+v", services)
 	activeServices := util.StringSet{}
 	for _, service := range services {
-		activeServices.Insert(service.Name)
-		info, exists := proxier.getServiceInfo(service.Name)
+		qualifiedServiceName := service.Namespace + ":" + service.Name
+		activeServices.Insert(qualifiedServiceName)
+		info, exists := proxier.getServiceInfo(qualifiedServiceName)
 		serviceIP := net.ParseIP(service.Spec.PortalIP)
 		// TODO: check health of the socket?  What if ProxyLoop exited?
 		if exists && info.portalPort == service.Spec.Port && info.portalIP.Equal(serviceIP) {
 			continue
 		}
 		if exists && (info.portalPort != service.Spec.Port || !info.portalIP.Equal(serviceIP) || !ipsEqual(service.Spec.PublicIPs, info.publicIP)) {
-			glog.V(4).Infof("Something changed for service %q: stopping it", service.Name)
-			err := proxier.closePortal(service.Name, info)
+			glog.V(4).Infof("Something changed for service %q: stopping it", qualifiedServiceName)
+			err := proxier.closePortal(qualifiedServiceName, info)
 			if err != nil {
-				glog.Errorf("Failed to close portal for %q: %v", service.Name, err)
+				glog.Errorf("Failed to close portal for %q: %v", qualifiedServiceName, err)
 			}
-			err = proxier.stopProxy(service.Name, info)
+			err = proxier.stopProxy(qualifiedServiceName, info)
 			if err != nil {
-				glog.Errorf("Failed to stop service %q: %v", service.Name, err)
+				glog.Errorf("Failed to stop service %q: %v", qualifiedServiceName, err)
 			}
 		}
-		glog.V(1).Infof("Adding new service %q at %s:%d/%s (local :%d)", service.Name, serviceIP, service.Spec.Port, service.Spec.Protocol, service.Spec.ProxyPort)
-		info, err := proxier.addServiceOnPort(service.Name, service.Spec.Protocol, service.Spec.ProxyPort, udpIdleTimeout)
+		glog.V(1).Infof("Adding new service %q at %s:%d/%s (local :%d)", qualifiedServiceName, serviceIP, service.Spec.Port, service.Spec.Protocol, service.Spec.ProxyPort)
+		info, err := proxier.addServiceOnPort(qualifiedServiceName, service.Spec.Protocol, service.Spec.ProxyPort, udpIdleTimeout)
 		if err != nil {
-			glog.Errorf("Failed to start proxy for %q: %v", service.Name, err)
+			glog.Errorf("Failed to start proxy for %q: %v", qualifiedServiceName, err)
 			continue
 		}
 		info.portalIP = serviceIP
@@ -495,11 +496,11 @@ func (proxier *Proxier) OnUpdate(services []api.Service) {
 		info.stickyMaxAgeMinutes = 180
 		glog.V(4).Infof("info: %+v", info)
 
-		err = proxier.openPortal(service.Name, info)
+		err = proxier.openPortal(qualifiedServiceName, info)
 		if err != nil {
-			glog.Errorf("Failed to open portal for %q: %v", service.Name, err)
+			glog.Errorf("Failed to open portal for %q: %v", qualifiedServiceName, err)
 		}
-		proxier.loadBalancer.NewService(service.Name, info.sessionAffinityType, info.stickyMaxAgeMinutes)
+		proxier.loadBalancer.NewService(qualifiedServiceName, info.sessionAffinityType, info.stickyMaxAgeMinutes)
 	}
 	proxier.mu.Lock()
 	defer proxier.mu.Unlock()


### PR DESCRIPTION
This is just to show you what I've done that seems to be working and gather feedback if this is not a feasable solution.  I need to clean it up and put it into an actual k8s request and so some in depth testing but this allows me to have create the services with the same name and curl them both


```
[vagrant@openshiftdev ~]$ osc get -n ns1 services && osc get -n ns2 services
NAME                LABELS                            SELECTOR            IP                  PORT
database            template=ruby-helloworld-sample   name=database       172.30.17.125       5434
NAME                LABELS                            SELECTOR            IP                  PORT
database            template=ruby-helloworld-sample   name=database       172.30.17.200       5434
[vagrant@openshiftdev ~]$ osc get -n ns1 pods && osc get -n ns2 pods
POD                 IP                  CONTAINER(S)               IMAGE(S)            HOST                           LABELS                                                                                          STATUS
database-1-r4y5g    172.17.0.28         ruby-helloworld-database   mysql               openshiftdev.local/127.0.0.1   deployment=database-1,deploymentconfig=database,name=database,template=ruby-helloworld-sample   Running
POD                 IP                  CONTAINER(S)               IMAGE(S)            HOST                           LABELS                                                                                          STATUS
database-1-wgqmy    172.17.0.29         ruby-helloworld-database   mysql               openshiftdev.local/127.0.0.1   deployment=database-1,deploymentconfig=database,name=database,template=ruby-helloworld-sample   Running

[vagrant@openshiftdev ~]$ curl 172.30.17.125:5434
5.6.23y{}%<?gh��TL_x`Uk;%B`<mysql_native_password!��#08S01Got packets out of order

[vagrant@openshiftdev ~]$ curl 172.30.17.200:5434
5.6.23e'0\\=X$��H|[2(mqp\^Dtmysql_native_password!��#08S01Got packets out of order[vagrant@openshiftdev ~]$ 
[vagrant@openshiftdev ~]$ 

[vagrant@openshiftdev ~]$ sudo iptables -t nat -L
Chain PREROUTING (policy ACCEPT)
target     prot opt source               destination         
DOCKER     all  --  anywhere             anywhere             ADDRTYPE match dst-type LOCAL
KUBE-PORTALS-CONTAINER  all  --  anywhere             anywhere            

Chain INPUT (policy ACCEPT)
target     prot opt source               destination         

Chain OUTPUT (policy ACCEPT)
target     prot opt source               destination         
DOCKER     all  --  anywhere            !loopback/8           ADDRTYPE match dst-type LOCAL
KUBE-PORTALS-HOST  all  --  anywhere             anywhere            

Chain POSTROUTING (policy ACCEPT)
target     prot opt source               destination         
MASQUERADE  all  --  172.17.0.0/16        anywhere            

Chain DOCKER (2 references)
target     prot opt source               destination         

Chain KUBE-PORTALS-CONTAINER (1 references)
target     prot opt source               destination         
REDIRECT   tcp  --  anywhere             172.30.17.2          /* default:kubernetes */ tcp dpt:https redir ports 43305
REDIRECT   tcp  --  anywhere             172.30.17.1          /* default:kubernetes-ro */ tcp dpt:http redir ports 40680
REDIRECT   tcp  --  anywhere             172.30.17.125        /* ns1:database */ tcp dpt:sgi-arrayd redir ports 57244
REDIRECT   tcp  --  anywhere             172.30.17.200        /* ns2:database */ tcp dpt:sgi-arrayd redir ports 48135

Chain KUBE-PORTALS-HOST (1 references)
target     prot opt source               destination         
DNAT       tcp  --  anywhere             172.30.17.2          /* default:kubernetes */ tcp dpt:https to:10.0.2.15:43305
DNAT       tcp  --  anywhere             172.30.17.1          /* default:kubernetes-ro */ tcp dpt:http to:10.0.2.15:40680
DNAT       tcp  --  anywhere             172.30.17.125        /* ns1:database */ tcp dpt:sgi-arrayd to:10.0.2.15:57244
DNAT       tcp  --  anywhere             172.30.17.200        /* ns2:database */ tcp dpt:sgi-arrayd to:10.0.2.15:48135

```