### PR TITLE
prototype alternate manifest storage

### DIFF
--- a/pkg/image/registry/image/etcd/etcd.go
+++ b/pkg/image/registry/image/etcd/etcd.go
@@ -42,6 +42,8 @@ func NewREST(optsGetter restoptions.Getter) (*REST, error) {
 		UpdateStrategy: image.Strategy,
 
 		ReturnDeletedObject: false,
+
+		Decorator: image.Strategy.Decorate,
 	}
 
 	if err := restoptions.ApplyOptions(optsGetter, store, false, storage.NoTriggerPublisher); err != nil {

--- a/pkg/image/registry/image/manifest_storage.go
+++ b/pkg/image/registry/image/manifest_storage.go
@@ -1,0 +1,44 @@
+package image
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+
+	kapi "k8s.io/kubernetes/pkg/api"
+)
+
+type ManifestStorage interface {
+	CreateOrUpdateManifest(ctx kapi.Context, id string, manifest string) error
+	GetManifest(id string) (string, error)
+	DeleteManifest(ctx kapi.Context, id string) error
+}
+
+type FileManifestStorage struct {
+	Root string
+}
+
+func (f *FileManifestStorage) CreateOrUpdateManifest(ctx kapi.Context, id string, manifest string) error {
+	err := ensureDirectory(f.Root)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path.Join(f.Root, id), []byte(manifest), 0750)
+}
+
+func (f *FileManifestStorage) GetManifest(id string) (string, error) {
+	bytes, err := ioutil.ReadFile(path.Join(f.Root, id))
+	if err != nil {
+		return "", err
+	}
+	return string(bytes), nil
+}
+
+func (f *FileManifestStorage) DeleteManifest(ctx kapi.Context, id string) error {
+	// TODO
+	return nil
+}
+
+func ensureDirectory(dir string) error {
+	return os.MkdirAll(dir, 0750)
+}


### PR DESCRIPTION
@mfojtik - we still need to do all the necessary investigation on etcd3 but this sure seems pretty easy if we had to move storage to the registry and maintain backwards compatibility in the api with retrieving the manifests.  Well, disregarding the fact that none of this is configurable.  But I think general concept is there.
